### PR TITLE
Fixed footer scrollbar problem.

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -38,7 +38,7 @@ function LazyStatusBadge() {
   return (
     <div 
       ref={iframeRef}
-      className="rounded max-w-full h-auto"
+      className="rounded max-w-full"
       style={{ width: '250px', height: '30px' }}
     >
       {isVisible ? (


### PR DESCRIPTION
The scrollbar was created due to the “h-auto” class in the iframe in the LazyStatusBadge function. This was removed and the footer was made to remain static.